### PR TITLE
Fix off-by-one error stemming from incorrect parameter name

### DIFF
--- a/Bluewire.IntervalTree.UnitTests/Bluewire.IntervalTree.UnitTests.csproj
+++ b/Bluewire.IntervalTree.UnitTests/Bluewire.IntervalTree.UnitTests.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PerMinuteSnapshotIntervalTree32Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RitCalculator32SanityChecks.cs" />
     <Compile Include="RitCalculator32Tests.cs" />

--- a/Bluewire.IntervalTree.UnitTests/PerMinuteSnapshotIntervalTree32Tests.cs
+++ b/Bluewire.IntervalTree.UnitTests/PerMinuteSnapshotIntervalTree32Tests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Bluewire.IntervalTree.UnitTests
+{
+    [TestFixture]
+    public class PerMinuteSnapshotIntervalTree32Tests
+    {
+        [Test]
+        public void QueryingSnapshotImmediatelyBeforeStart_DoesNotIncludeEntry()
+        {
+            var tree = new PerMinuteSnapshotIntervalTree32();
+            var datestamp = new DateTimeOffset(2017, 05, 09, 11, 37, 10, 277, TimeSpan.FromHours(1));
+            var snapshot = new DateTime(2017, 05, 09, 11, 37, 0);   // Rounded down to the previous minute.
+            var entry = tree.CalculateNodeWithoutEnd(datestamp);
+
+            var query = tree.GenerateQuery(snapshot, snapshot);
+            Assert.False(query.ToFilter()(entry));
+        }
+
+        [Test]
+        public void QueryingSnapshotImmediatelyAfterStart_IncludesEntry()
+        {
+            var tree = new PerMinuteSnapshotIntervalTree32();
+            var datestamp = new DateTimeOffset(2017, 05, 09, 11, 37, 10, 277, TimeSpan.FromHours(1));
+            var snapshot = new DateTime(2017, 05, 09, 11, 38, 0);   // Rounded up to the next minute.
+            var entry = tree.CalculateNodeWithoutEnd(datestamp);
+
+            var query = tree.GenerateQuery(snapshot, snapshot);
+            Assert.True(query.ToFilter()(entry));
+        }
+
+        [Test]
+        public void QueryingSnapshotExactlyAtStart_IncludesEntry()
+        {
+            var tree = new PerMinuteSnapshotIntervalTree32();
+            var datestamp = new DateTimeOffset(2017, 05, 09, 11, 37, 0, 0, TimeSpan.FromHours(1));
+            var snapshot = new DateTime(2017, 05, 09, 11, 37, 0);
+            var entry = tree.CalculateNodeWithoutEnd(datestamp);
+
+            var query = tree.GenerateQuery(snapshot, snapshot);
+            Assert.True(query.ToFilter()(entry));
+        }
+
+        [Test]
+        public void QueryingSnapshotExactlyAtEnd_DoesNotIncludeEntry()
+        {
+            var tree = new PerMinuteSnapshotIntervalTree32();
+            var datestamp = new DateTimeOffset(2017, 05, 09, 11, 37, 0, 0, TimeSpan.FromHours(1));
+            var snapshot = new DateTime(2017, 05, 09, 11, 37, 0);
+            var entry = tree.CalculateNode(new DateTimeOffset(2005, 1, 1, 0, 0, 0, TimeSpan.FromHours(1)), datestamp);
+
+            var query = tree.GenerateQuery(snapshot, snapshot);
+            Assert.False(query.ToFilter()(entry));
+        }
+    }
+}

--- a/Bluewire.IntervalTree/PerMinuteSnapshotIntervalTree32.cs
+++ b/Bluewire.IntervalTree/PerMinuteSnapshotIntervalTree32.cs
@@ -24,7 +24,7 @@ namespace Bluewire.IntervalTree
             this.epochYear = epochYear;
         }
 
-        protected override int MapIntervalBoundary(DateTimeOffset value, out bool isExact)
+        protected override int MapIntervalBoundary(DateTimeOffset value, out bool isRoundedDown)
         {
             var yearsBeyondTheEpoch = value.Year - epochYear;
 
@@ -60,16 +60,16 @@ namespace Bluewire.IntervalTree
 
             if(value.Second != 0)
             {
-                isExact = false;
+                isRoundedDown = true;
             }
             else if(value.Millisecond != 0)
             {
-                isExact = false;
+                isRoundedDown = true;
             }
             else
             {
                 // Slow path, within the very millisecond of a minute boundary.
-                isExact = value.TimeOfDay - new TimeSpan(value.Hour, value.Minute, 0) == TimeSpan.Zero;
+                isRoundedDown = value.TimeOfDay - new TimeSpan(value.Hour, value.Minute, 0) != TimeSpan.Zero;
             }
             Debug.Assert((lowBits & yearsShifted) == 0);
             return lowBits | yearsShifted;

--- a/Bluewire.IntervalTree/Properties/AssemblyInfo.cs
+++ b/Bluewire.IntervalTree/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0")]
-[assembly: AssemblyFileVersion("2.0.0")]
+[assembly: AssemblyVersion("2.0.1")]
+[assembly: AssemblyFileVersion("2.0.1")]


### PR DESCRIPTION
refs E-27726