### PR TITLE
Add 'Error' status to RitStatus enumeration

### DIFF
--- a/Bluewire.IntervalTree/Bluewire.IntervalTree.csproj
+++ b/Bluewire.IntervalTree/Bluewire.IntervalTree.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/Bluewire.IntervalTree/RitStatus.cs
+++ b/Bluewire.IntervalTree/RitStatus.cs
@@ -8,6 +8,7 @@ namespace Bluewire.IntervalTree
     [Flags]
     public enum RitStatus
     {
+        Error = -1,
         Valid = 0,
         NodeNeedsUpdate = 0x0001,
         BoundsNeedUpdate = 0x0002,


### PR DESCRIPTION
The 'Error' status applies to nodes which could not be created for some
reason. It has a negative integer value, so that `> 0` queries looking
for nodes to update will skip it.

Nodes in this status probably require manual intervention to fix.

refs EP-43067

Bluewire.IntervalTree: 3.0.0 -> 3.1.0