### PR TITLE
Require that inverse-mapped collections do not use optimistic locking

### DIFF
--- a/Bluewire.NHibernate.Audit.UnitTests/AuditModelBuilderTests.cs
+++ b/Bluewire.NHibernate.Audit.UnitTests/AuditModelBuilderTests.cs
@@ -60,5 +60,59 @@ namespace Bluewire.NHibernate.Audit.UnitTests
 
             Assert.Throws<AuditConfigurationException>(() => new AuditModelBuilder().AddFromConfiguration(cfg));
         }
+
+        [Test]
+        public void InverseCollectionsMustBeOmittedFromOptimisticLocking()
+        {
+            var cfg = new Configuration();
+            cfg.DataBaseIntegration(d =>
+            {
+                d.Dialect<SQLiteDialect>();
+            });
+
+            var mapper = new ModelMapper();
+            mapper.Class<InverseReferencableEntity>(e =>
+            {
+                e.Id(i => i.Id, i => i.Generator(new HighLowGeneratorDef()));
+                e.Property(i => i.String);
+                e.Property(i => i.OwnerId);
+            });
+
+            mapper.Class<EntityWithAuditedInverseCollection>(e =>
+            {
+                e.Id(i => i.Id, i => i.Generator(new AssignedGeneratorDef()));
+                e.Property(i => i.Value);
+                e.List(i => i.Entities,
+                    c =>
+                    {
+                        c.Table("EntityWithAuditedInverseCollectionEntities");
+                        c.Inverse(true);
+
+                        // Should cause an error.
+                        c.OptimisticLock(true);
+
+                        c.Cascade(Cascade.All); // Not required by audit. Convenience for testing.
+                        c.Key(k => k.Column("OwnerId"));
+                    },
+                    r => r.OneToMany());
+                e.Version(i => i.VersionId, v => { });
+            });
+            mapper.Class<EntityWithAuditedInverseCollectionAuditHistory>(e =>
+            {
+                e.Id(i => i.AuditId, i => i.Generator(new HighLowGeneratorDef()));
+                e.Property(i => i.Id);
+                e.Property(i => i.VersionId);
+                e.Property(i => i.Value);
+                e.Property(i => i.PreviousVersionId);
+                e.Property(i => i.AuditDatestamp, p => p.Type<DateTimeOffsetAsIntegerUserType>());
+                e.Property(i => i.AuditedOperation, p => p.Type<AuditedOperationEnumType>());
+                e.Mutable(false);
+            });
+            cfg.AddMapping(mapper.CompileMappingForAllExplicitlyAddedEntities());
+
+            var modelBuilder = new AuditModelBuilder();
+
+            Assert.That(() => modelBuilder.AddFromConfiguration(cfg), Throws.InstanceOf<AuditConfigurationException>().With.Message.Contains("inverse"));
+        }
     }
 }

--- a/Bluewire.NHibernate.Audit.UnitTests/Simple/EntityWithAuditedInverseCollection.cs
+++ b/Bluewire.NHibernate.Audit.UnitTests/Simple/EntityWithAuditedInverseCollection.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using Bluewire.NHibernate.Audit.Attributes;
+
+namespace Bluewire.NHibernate.Audit.UnitTests.Simple
+{
+    [AuditableEntity(typeof(EntityWithAuditedInverseCollectionAuditHistory))]
+    public class EntityWithAuditedInverseCollection
+    {
+        public EntityWithAuditedInverseCollection()
+        {
+            Entities = new List<InverseReferencableEntity>();
+        }
+
+        public virtual int Id { get; set; }
+        public virtual string Value { get; set; }
+        public virtual int VersionId { get; set; }
+
+        public virtual IList<InverseReferencableEntity> Entities { get; protected set; }
+    }
+
+    public class InverseReferencableEntity
+    {
+        public virtual int Id { get; set; }
+        public virtual string String { get; set; }
+        public virtual int OwnerId { get; set; }
+    }
+
+    public class EntityWithAuditedInverseCollectionAuditHistory : EntityAuditHistoryBase<int, int>
+    {
+        public virtual string Value { get; set; }
+    }
+}

--- a/Bluewire.NHibernate.Audit.UnitTests/Simple/EntityWithAuditedInverseCollectionPersistenceTests.cs
+++ b/Bluewire.NHibernate.Audit.UnitTests/Simple/EntityWithAuditedInverseCollectionPersistenceTests.cs
@@ -1,0 +1,95 @@
+using System.Linq;
+using Bluewire.Common.Time;
+using Bluewire.NHibernate.Audit.Support;
+using Bluewire.NHibernate.Audit.UnitTests.Util;
+using NHibernate.Cfg;
+using NHibernate.Linq;
+using NHibernate.Mapping.ByCode;
+using NUnit.Framework;
+
+namespace Bluewire.NHibernate.Audit.UnitTests.Simple
+{
+    [TestFixture]
+    public class EntityWithInverseCollectionPersistenceTests
+    {
+        private TemporaryDatabase db;
+        private MockClock clock = new MockClock();
+
+        public EntityWithInverseCollectionPersistenceTests()
+        {
+            db = TemporaryDatabase.Configure(Configure);
+        }
+
+        [Test]
+        public void CanSaveEntityWithInverseCollection()
+        {
+            using (var session = db.CreateSession())
+            {
+                var entity = new EntityWithAuditedInverseCollection
+                {
+                    Id = 42,
+                    Value = "Initial value",
+                };
+                session.Save(entity);
+                entity.Entities.Add(new InverseReferencableEntity { String = "2", OwnerId = entity.Id });
+                session.Flush();
+
+                var audited = session.Query<EntityWithAuditedInverseCollectionAuditHistory>().Single(h => h.Id == 42);
+
+                Assert.AreEqual(42, audited.Id);
+                Assert.AreEqual(entity.VersionId, audited.VersionId);
+                Assert.AreEqual(entity.Value, audited.Value);
+                Assert.AreEqual(null, audited.PreviousVersionId);
+                Assert.AreEqual(AuditedOperation.Add, audited.AuditedOperation);
+            }
+        }
+
+        private void Configure(Configuration cfg)
+        {
+            var mapper = new ModelMapper();
+            mapper.Class<InverseReferencableEntity>(e =>
+            {
+                e.Id(i => i.Id, i => i.Generator(new HighLowGeneratorDef()));
+                e.Property(i => i.String);
+                e.Property(i => i.OwnerId);
+            });
+
+            mapper.Class<EntityWithAuditedInverseCollection>(e =>
+            {
+                e.Id(i => i.Id, i => i.Generator(new AssignedGeneratorDef()));
+                e.Property(i => i.Value);
+                e.List(i => i.Entities,
+                    c =>
+                    {
+                        c.Table("EntityWithAuditedInverseCollectionEntities");
+                        c.Inverse(true);
+
+                        // Inverse-mapped collections MUST specify this as 'false'.
+                        // If they do not, later versions of NHibernate may increment the entity's version in
+                        // response to a change in the collection's contents, which breaks history as the entity
+                        // has not actually changed.
+                        c.OptimisticLock(false);
+
+                        c.Cascade(Cascade.All); // Not required by audit. Convenience for testing.
+                        c.Key(k => k.Column("OwnerId"));
+                    },
+                    r => r.OneToMany());
+                e.Version(i => i.VersionId, v => { });
+            });
+            mapper.Class<EntityWithAuditedInverseCollectionAuditHistory>(e =>
+            {
+                e.Id(i => i.AuditId, i => i.Generator(new HighLowGeneratorDef()));
+                e.Property(i => i.Id);
+                e.Property(i => i.VersionId);
+                e.Property(i => i.Value);
+                e.Property(i => i.PreviousVersionId);
+                e.Property(i => i.AuditDatestamp, p => p.Type<DateTimeOffsetAsIntegerUserType>());
+                e.Property(i => i.AuditedOperation, p => p.Type<AuditedOperationEnumType>());
+                e.Mutable(false);
+            });
+            cfg.AddMapping(mapper.CompileMappingForAllExplicitlyAddedEntities());
+
+            new AuditConfigurer(new DynamicAuditEntryFactory(), new ClockAuditDatestampProvider(clock)).IntegrateWithNHibernate(cfg);
+        }
+    }
+}

--- a/Bluewire.NHibernate.Audit/Bluewire.NHibernate.Audit.csproj
+++ b/Bluewire.NHibernate.Audit/Bluewire.NHibernate.Audit.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net48</TargetFrameworks>
-    <VersionPrefix>11.0.0</VersionPrefix>
+    <VersionPrefix>11.1.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This probably does not affect NHibernate 4, but under NHibernate 5 this causes 'action at a distance' when the collection's members prompt an update to the version of the entity which has the collection property.

refs EP-43891

Bluewire.NHibernate.Audit: 11.0.0 -> 11.1.0